### PR TITLE
update shared contexts section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can define shared contexts in Bacon like this:
       end
     end
 
-    context "A new array" do
+    describe "A new array" do
       behaves_like "an empty container"
     end
 


### PR DESCRIPTION
Changed the shared/behaves_like example to use the `describe` method, as `context` does not exist.
